### PR TITLE
Fixed mpg123 HTTPS redirect streaming issues.

### DIFF
--- a/mpg123player.rb
+++ b/mpg123player.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'httpclient'
 
 class MPG123Player
   include Observable
@@ -25,7 +26,10 @@ class MPG123Player
   def play(track)
     @last_track = track
     unless track.nil? || track.is_a?(Hash) && track[:error]
-      mpg123puts "load #{track["mpg123url"]}"
+      strhead   = HTTPClient.new.head(track['mpg123url'])
+      streamuri = strhead.header['Location'][0]
+      streamuri.sub! 'https', 'http'
+      mpg123puts "load #{streamuri}"
       @pstate = 2
     end
     changed


### PR DESCRIPTION
Fix plackback issues, where time is stuck at 00:00.

The problem lies in that mpg123 can't handle HTTPS. Soundcloud does supports HTTP, but redirects 

http://api.soundcloud.com/tracks/[tid]/stream?client_id=[cid]

to 

https://cf-media.sndcdn.com/[file]

links anyway. mpg123 is able to follow redirects, but not across protocol. This fix changes the HTTPS to HTTP. The sndcdn location is found by retrieving the headers only using an external library.

