### PR TITLE
Added user stream functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Without RVM you need to obtain write permissions with sudo:
 ## Usage
 From the terminal start with:
 <pre>
-  cloudruby          # query the latest 100 tracks from soundcloud 
+  cloudruby          # query the latest 100 tracks from soundcloud (dashboard with token)
   cloudruby $search  # query the latest 100 tracks that match the $search keyword
   
   # play a soundcloud url directly
@@ -43,6 +43,13 @@ Shortcuts:
 <tr><td>v | V        </td><td>About dialog</td></tr>
 <tr><td>Spacebar     </td><td>Toggle playback</td></tr>
 </table>
+
+## User stream (also dashboard) 
+By configuring an access token for your account the latest 100 tracks
+from your stream are loaded, much like being logged in on soundcloud
+website.
+
+[Generate your token here](http://ninsei.thruhere.net/soundcloud.php)
 
 ## Download
 
@@ -66,6 +73,7 @@ Cloudruby can be customized through **~/.cloudruby.json** file.
 ```json
 {
   "download_dir": "~/music",
+  "token": "0-00000-00000000-000000000000000",
   "curses": {
     "colors": {
       "default": ["white", "black"],
@@ -87,6 +95,8 @@ You can use only these colors: "black", "blue", "cyan", "green", "magenta", "red
 Paul Koch [kulpae]
 
 http://www.uraniumlane.net/users/kulpae
+
+Contributors [magnific0](http://www.github.com/magnific0) (user stream).
 
 ## License
 see LICENSE.

--- a/cloudruby
+++ b/cloudruby
@@ -11,7 +11,7 @@ require_relative 'ncurses_ui.rb'
 class Cloudruby
   def init(q, config)
     @config = config
-    @cloud = SoundCloud.new "76796f79392f9398288cdac3fe3391c0"
+    @cloud = SoundCloud.new "9b44801444d1c58c6884e4bac0f381bc", @config[:token]
     @player = MPG123Player.new
     @ui = NCursesUI.new self, (@config[:ncurses] || @config[:curses])
 

--- a/mpg123player.rb
+++ b/mpg123player.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'httpclient'
 
 class MPG123Player
   include Observable
@@ -25,7 +26,10 @@ class MPG123Player
   def play(track)
     @last_track = track
     unless track.nil? || track.is_a?(Hash) && track[:error]
-      mpg123puts "load #{track["mpg123url"]}"
+      strhead   = HTTPClient.new.head(track['mpg123url'])
+      streamuri = strhead.header['Location'][0]
+      streamuri.sub! 'https', 'http'
+      mpg123puts "load #{streamuri}"
       @pstate = 2
     end
     changed


### PR DESCRIPTION
I have just reset my fork just to seperate issues. Request #12 was automatically closed. I have moved the user stream functionality to a seperate branch for now. We can work on a solution and merge later.

This code adds the ability for users to listen to their own user stream (https://soundcloud.com/stream) through cloudruby. The stream is automatically selected if the search query is blank (no arguments given to cloudruby)

An access token must be generated and set in the config file. The server-side PHP file is added to the repository as soundcloud.php. A live version is available through http://ninsei.thruhere.net/soundcloud.php.
