### PR TITLE
Parse commandline args as separate songs for playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,24 @@ Without RVM you need to obtain write permissions with sudo:
 ## Usage
 From the terminal start with:
 <pre>
-  cloudruby          # query the latest 100 tracks from soundcloud
-  cloudruby $search  # query the latest 100 tracks that match the $search keyword
+  cloudruby [--config-args] [(search terms|track urls)]
 
-  # play a soundcloud url directly
+  # Examples
+
+  cloudruby          # query the latest 100 tracks from soundcloud
+  cloudruby $search  # query the latest 100 tracks that match the $search keywords
+
+  ## play a soundcloud url directly
   cloudruby http://soundcloud.com/crassmix/feint-clockwork-hearts-crass
+
+  ## create a playlist from arguments (urls and/or grouped search keywords)
+  cloudruby --no-shuffle=true https://soundcloud.com/adapt77/auto-ok-ecophal manicanparty heart "sellorekt thunderbolt" https://soundcloud.com/wearesoundspace/premiere-malbetrieb-ghetto "elektroschneider lenny"
+  > search terms are grouped when quoted or adjacent to urls or quoted strings
+
+  ## create a playlist from a pipe
+  > stdin is also parsed as arguments if piped into the process
+  cloudruby --no-shuffle=true < local-playlist-filename
+  printf "sellorekt iris\nmanicanparty eyes" | cloudruby
 </pre>
 
 Shortcuts:

--- a/bin/cloudruby
+++ b/bin/cloudruby
@@ -21,7 +21,6 @@ end
 @query = []
 cfile = File.join Dir.home, ".#{File.basename($0)}.json"
 
-puts "argv:"
 nextsearch = []
 ARGV.each do |a|
   if a[0, 2] == "--"
@@ -44,8 +43,6 @@ if !nextsearch.empty?
     @query.push(nextsearch.join " ")
     nextsearch = []
 end
-puts @query
-puts ":argv"
 
 if @config[:noconfig].nil? && File.readable?(cfile)
   File.open cfile, 'r' do |file|

--- a/bin/cloudruby
+++ b/bin/cloudruby
@@ -21,15 +21,31 @@ end
 @query = []
 cfile = File.join Dir.home, ".#{File.basename($0)}.json"
 
+puts "argv:"
+nextsearch = []
 ARGV.each do |a|
   if a[0, 2] == "--"
     a = a[2..-1]
     key, value = a.split("=", 2)
     @config[key.to_sym] = value || true
   else
-    @query << a
+      if a.match(/(\s|http)/)
+          if !nextsearch.empty?
+            @query.push(nextsearch.join " ")
+            nextsearch = []
+          end
+          @query.push(a)
+      else
+          nextsearch.push(a)
+      end
   end
 end
+if !nextsearch.empty?
+    @query.push(nextsearch.join " ")
+    nextsearch = []
+end
+puts @query
+puts ":argv"
 
 if @config[:noconfig].nil? && File.readable?(cfile)
   File.open cfile, 'r' do |file|
@@ -39,8 +55,6 @@ if @config[:noconfig].nil? && File.readable?(cfile)
 end
 
 @config[:download_dir] ||= Dir.pwd
-
-@query = @query.join " "
 
 c = Cloudruby.new
 c.init @query, @config

--- a/bin/cloudruby
+++ b/bin/cloudruby
@@ -21,8 +21,18 @@ end
 @query = []
 cfile = File.join Dir.home, ".#{File.basename($0)}.json"
 
+all_args = ARGV
+
+if !$stdin.tty?
+    $stdin.each_line do |line|
+        all_args.push(line)
+    end
+    # Reset to interactive terminal session
+    $stdin.reopen("/dev/tty")
+end
+
 nextsearch = []
-ARGV.each do |a|
+all_args.each do |a|
   if a[0, 2] == "--"
     a = a[2..-1]
     key, value = a.split("=", 2)

--- a/lib/soundcloud.rb
+++ b/lib/soundcloud.rb
@@ -20,12 +20,6 @@ class SoundCloud
 
   def load_playlist(args = nil, offset = 0)
     args = [] unless args && !args.empty?
-    # If there are any urls in the search,
-    # Loop over whitespace separated strings in search.
-    #  First make each a separate song/search.
-    #  Later group search terms when quoted?
-    print "for each in args:"
-    print args
     @tracks = []
     args.each do |search|
         if search =~ /\s*http(s)?:\/\/(www.)?soundcloud.com.*/
@@ -46,7 +40,6 @@ class SoundCloud
             t["bpm"] = t["bpm"].nil? ? 0 : t["bpm"].to_i
             t[:error] = "Not streamable" if t["stream_url"].nil?
             t["searchterm"] = search
-            # t
             @tracks << t
         end
     end

--- a/lib/soundcloud.rb
+++ b/lib/soundcloud.rb
@@ -26,13 +26,8 @@ class SoundCloud
     #  Later group search terms when quoted?
     print "for each in args:"
     print args
-    puts ""
-    for index in 0 ... args.size
-        puts "args[#{index}] = #{args[index].inspect}"
-    end
     @tracks = []
     args.each do |search|
-        puts search
         if search =~ /\s*http(s)?:\/\/(www.)?soundcloud.com.*/
             url = "https://api.soundcloud.com/resolve.json?url=%s&client_id=%s" % [CGI.escape(search), @cid]
         else
@@ -54,10 +49,6 @@ class SoundCloud
             # t
             @tracks << t
         end
-        puts 'next search'
-    end
-    @tracks.each do |t|
-        puts t["searchterm"]
     end
     changed
     notify_observers :state =>:load, :tracks => @tracks

--- a/lib/soundcloud.rb
+++ b/lib/soundcloud.rb
@@ -18,30 +18,46 @@ class SoundCloud
     @dthread.run
   end
 
-  def load_playlist(search = nil, offset = 0)
-    search = "" unless search && !search.empty?
+  def load_playlist(args = nil, offset = 0)
+    args = [] unless args && !args.empty?
     # If there are any urls in the search,
     # Loop over whitespace separated strings in search.
     #  First make each a separate song/search.
     #  Later group search terms when quoted?
-    if search =~ /\s*http(s)?:\/\/(www.)?soundcloud.com.*/
-      url = "https://api.soundcloud.com/resolve.json?url=%s&client_id=%s" % [CGI.escape(search), @cid]
-    else
-      url = "https://api.soundcloud.com/tracks.json?client_id=%s&filter=streamable&limit=%d&offset=%d&q=%s" \
-        % [@cid, LIMIT, offset, CGI.escape(search)]
+    print "for each in args:"
+    print args
+    puts ""
+    for index in 0 ... args.size
+        puts "args[#{index}] = #{args[index].inspect}"
     end
-    c = open(url) do |io|
-      io.readlines
-    end.join
-    @tracks = JSON.parse c
-    @tracks = [@tracks] if @tracks.is_a? Hash
-    @tracks.map! do |t|
-      t["mpg123url"] = client_url t['stream_url']
-      t["download"] = client_url t['download_url']
-      t["duration"] = t["duration"].nil? ? 0 : t["duration"].to_i/1000
-      t["bpm"] = t["bpm"].nil? ? 0 : t["bpm"].to_i
-      t[:error] = "Not streamable" if t["stream_url"].nil?
-      t
+    @tracks = []
+    args.each do |search|
+        puts search
+        if search =~ /\s*http(s)?:\/\/(www.)?soundcloud.com.*/
+            url = "https://api.soundcloud.com/resolve.json?url=%s&client_id=%s" % [CGI.escape(search), @cid]
+        else
+            url = "https://api.soundcloud.com/tracks.json?client_id=%s&filter=streamable&limit=%d&offset=%d&q=%s" \
+                % [@cid, LIMIT, offset, CGI.escape(search)]
+        end
+        c = open(url) do |io|
+            io.readlines
+        end.join
+        trx = JSON.parse c
+        trx = [trx] if trx.is_a? Hash
+        trx.map! do |t|
+            t["mpg123url"] = client_url t['stream_url']
+            t["download"] = client_url t['download_url']
+            t["duration"] = t["duration"].nil? ? 0 : t["duration"].to_i/1000
+            t["bpm"] = t["bpm"].nil? ? 0 : t["bpm"].to_i
+            t[:error] = "Not streamable" if t["stream_url"].nil?
+            t["searchterm"] = search
+            # t
+            @tracks << t
+        end
+        puts 'next search'
+    end
+    @tracks.each do |t|
+        puts t["searchterm"]
     end
     changed
     notify_observers :state =>:load, :tracks => @tracks

--- a/lib/soundcloud.rb
+++ b/lib/soundcloud.rb
@@ -20,6 +20,10 @@ class SoundCloud
 
   def load_playlist(search = nil, offset = 0)
     search = "" unless search && !search.empty?
+    # If there are any urls in the search,
+    # Loop over whitespace separated strings in search.
+    #  First make each a separate song/search.
+    #  Later group search terms when quoted?
     if search =~ /\s*http(s)?:\/\/(www.)?soundcloud.com.*/
       url = "https://api.soundcloud.com/resolve.json?url=%s&client_id=%s" % [CGI.escape(search), @cid]
     else


### PR DESCRIPTION
This changes the argument handling to allow for 1+ grouped search terms and handling stdin (pipes not tty) the same as arguments to allow piping in a "playlist" set of search terms and/or song urls.

```
  cloudruby [--config-args] [(search terms|track urls)]

  # Examples

  cloudruby          # query the latest 100 tracks from soundcloud
  cloudruby $search  # query the latest 100 tracks that match the $search keywords

  ## play a soundcloud url directly
  cloudruby http://soundcloud.com/crassmix/feint-clockwork-hearts-crass

  ## create a playlist from arguments (urls and/or grouped search keywords)
  cloudruby --no-shuffle=true https://soundcloud.com/adapt77/auto-ok-ecophal manicanparty heart "sellorekt thunderbolt" https://soundcloud.com/wearesoundspace/premiere-malbetrieb-ghetto "elektroschneider lenny"
  > search terms are grouped when quoted or adjacent to urls or quoted strings

  ## create a playlist from a pipe
  > stdin is also parsed as arguments if piped into the process
  cloudruby --no-shuffle=true < local-playlist-filename
  printf "sellorekt iris\nmanicanparty eyes" | cloudruby
```